### PR TITLE
Add response parameter on promise resolution

### DIFF
--- a/lib/restler-q.js
+++ b/lib/restler-q.js
@@ -13,7 +13,7 @@ function wrap(r) {
       return;
     }
 
-    defer.resolve(result);
+    defer.resolve(result, response);
   });
 
   r.on('fail', function(result, response) {
@@ -22,7 +22,7 @@ function wrap(r) {
       return;
     }
 
-    defer.reject(result);
+    defer.reject(result, response);
   });
 
   r.on('error', function(err, response) {
@@ -31,7 +31,7 @@ function wrap(r) {
       return;
     }
 
-    defer.reject(err);
+    defer.reject(err, response);
   });
 
   r.on('abort', function() {


### PR DESCRIPTION
The way restler-q works right now, it discards the http response information during promise resolution. This can be useful for testing exactly why a failure occurred, such as when you want to know if a failure happened due to a 404 or a 403. This patch fixes this.
