### PR TITLE
Upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "url": "https://github.com/troupe/restler-q/issues"
   },
   "dependencies": {
-    "q": "^1.0.0",
-    "restler": "^3.0.0"
+    "q": "^1.5.1",
+    "restler": "^3.4.0"
   },
   "devDependencies": {
-    "mocha": "^2.0.0"
+    "mocha": "^7.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restler-q",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "description": "Q Wrapper for Restler",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The old version of Restler is dependent on qs, which has a high severity vulnerability (Prototype Pollution Protection Bypass, https://www.npmjs.com/advisories/1469). The upgrades solve the issue. 